### PR TITLE
Remove console.log(ao)

### DIFF
--- a/src/deployProcesses.mjs
+++ b/src/deployProcesses.mjs
@@ -228,8 +228,6 @@ export async function deployProcesses(customFilePath) {
   // Connect to the AO network
   const ao = connect();
 
-  console.log(ao)
-
   // Spawn processes
   let directory = {}
   for (const processInfo of processes) {


### PR DESCRIPTION
Really handy tool, going to use it in my workflow. In an effort to make the output a little less verbose, I'd like to suggest we remove the `console.log(ao)` which just prints a number of anonymous functions.